### PR TITLE
add db migration with initial scheama and retry logic

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,36 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+#
+# Note:
+# To comment out a single error:
+#   <!-- markdownlint-disable -->
+#   any violations you want
+#   <!-- markdownlint-restore -->
+#
+
+###############
+# Rules by id #
+###############
+MD004: false                  # Unordered list style
+MD007:
+  indent: 2                   # Unordered list indentation
+MD013:
+  line_length: 400            # Line length 80 is far to short
+MD026:
+  punctuation: ".,;:!。，；:"  # List of not allowed
+MD029: false                  # Ordered list item prefix
+MD033: false                  # Allow inline HTML
+MD036: false                  # Emphasis used instead of a heading
+MD041: false
+
+#################
+# Rules by tags #
+#################
+blank_lines: false  # Error on blank lines

--- a/.github/workflows/superlinter.yaml
+++ b/.github/workflows/superlinter.yaml
@@ -24,3 +24,4 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_JAVASCRIPT_STANDARD: false
+          VALIDATE_BASH: false

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,7 +1,7 @@
 const express = require('express')
 const cors = require('cors')
 const mountRoutes = require('./routes')
-// const db = require('./db')
+const db = require('./db')
 
 
 const app = express()
@@ -10,6 +10,8 @@ app.use(cors())
 app.get('/', (_req, res) => {
     res.json('Hello from the backend')
 })
+
+db.migrateUp()
 
 mountRoutes(app)
 

--- a/backend/db/index.js
+++ b/backend/db/index.js
@@ -8,7 +8,7 @@ const dbDetails = {
     database: process.env.DB_DATABASE,
     password: process.env.DB_PASSWORD,
     // port: 1234 // Intentionally wrong port for testing DB conn failure
-    port: process.env.DB_PORT    
+    port: process.env.DB_PORT
 }
 
 const pool = new Pool(dbDetails)
@@ -19,7 +19,7 @@ const sleep = promisify(setTimeout)
 async function migrateUp() {
     client.connect()
     var retryCounter = 5
-    for (i = 0; i < retryCounter; i ++) {
+    for (var i = 0; i < retryCounter; i ++) {
         try {
             await migrate({client}, "migration")
             console.log('Finished DB migration successfully')

--- a/backend/db/index.js
+++ b/backend/db/index.js
@@ -1,15 +1,44 @@
-const { Pool } = require('pg')
-const pool = new Pool({
+const { Pool, Client } = require('pg')
+const { migrate } = require('postgres-migrations')
+const { promisify } = require('util')
+
+const dbDetails = {
     host: process.env.DB_HOST,
     user: process.env.DB_USER,
     database: process.env.DB_DATABASE,
     password: process.env.DB_PASSWORD,
     // port: 1234 // Intentionally wrong port for testing DB conn failure
-    port: process.env.DB_PORT
-})
+    port: process.env.DB_PORT    
+}
+
+const pool = new Pool(dbDetails)
+const client = new Client(dbDetails)
+
+const sleep = promisify(setTimeout)
+
+async function migrateUp() {
+    client.connect()
+    var retryCounter = 5
+    for (i = 0; i < retryCounter; i ++) {
+        try {
+            await migrate({client}, "migration")
+            console.log('Finished DB migration successfully')
+            client.end()
+            break
+        } catch (err) {
+            console.log(`Failed to run migrateUp. Tried ${i + 1} times`)
+            console.error(err)
+            await sleep(1000)
+        }
+    }
+}
 
 module.exports = {
     query: (text, params, callback) => {
         return pool.query(text, params, callback)
     },
+    client: () => {
+        return client()
+    },
+    migrateUp: migrateUp
 }

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -14,6 +14,14 @@ services:
       PGPASSWORD: ${DB_PASSWORD}
       PGDATABASE: ${DB_NAME}
       PGPORT: 5432
+    entrypoint:
+      [
+        "./wait-for-it.sh",
+        "db:5432",
+        "--",
+        "node",
+        "app.js"
+      ]      
   db:
     image: postgres:9.6
     restart: always

--- a/backend/migration/0001_add_aws_revision_tables.sql
+++ b/backend/migration/0001_add_aws_revision_tables.sql
@@ -1,0 +1,46 @@
+create table if not exists categories(
+    category_id int primary key,
+    type_id int not null,
+    category_name varchar(50) unique not null
+);
+
+create table if not exists category_types(
+    category_type_id int primary key,
+    category_type_name varchar(50) not null
+);
+
+create table if not exists sub_categories(
+    sub_category_id int primary key,
+    type_id int not null,
+    parent_category varchar (50) not null,
+    sub_category_name varchar(50) unique not null,
+    constraint fk_subcategory_in_category foreign key(sub_category_id) references categories(category_id),
+    constraint fk_type_in_category_types foreign key(type_id) references category_types(category_type_id)
+);
+
+create table if not exists summaries(
+    summary_id int primary key,
+    type_id int not null,
+    sub_category_id int not null,
+    summary text not null,
+    constraint fk_subcategory_in_subcategory foreign key(sub_category_id) references sub_categories(sub_category_id),
+    constraint fk_type_in_category_types foreign key(type_id) references category_types(category_type_id)    
+);
+
+create table if not exists revision_checklists(
+    revision_checklist_id int primary key,
+    type_id int not null,
+    sub_category_id int not null,
+    checklist text not null,
+    constraint fk_subcategory_in_subcategory foreign key(sub_category_id) references sub_categories(sub_category_id),
+    constraint fk_type_in_category_types foreign key(type_id) references category_types(category_type_id)    
+);
+
+create table if not exists pricing_models(
+    pricing_model_id int primary key,
+    type_id int not null,
+    sub_category_id int not null,
+    pricing_model text not null,
+    constraint fk_subcategory_in_subcategory foreign key(sub_category_id) references sub_categories(sub_category_id),
+    constraint fk_type_in_category_types foreign key(type_id) references category_types(category_type_id)
+);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -726,6 +726,15 @@
                 "xtend": "^4.0.0"
             }
         },
+        "postgres-migrations": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/postgres-migrations/-/postgres-migrations-5.1.1.tgz",
+            "integrity": "sha512-G5QgHhmgOUFJtkNsYi7tYXi2vit9hzJCm+HbsAVa9mhR6tW9lwX/o/s9Rbnx574BVRvkV5+gPWxGAP9l3FyBKg==",
+            "requires": {
+                "pg": "^8.5.1",
+                "sql-template-strings": "^2.2.2"
+            }
+        },
         "prompt": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/prompt/-/prompt-1.0.0.tgz",
@@ -900,6 +909,11 @@
             "requires": {
                 "readable-stream": "^3.0.0"
             }
+        },
+        "sql-template-strings": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/sql-template-strings/-/sql-template-strings-2.2.2.tgz",
+            "integrity": "sha1-PxFQiiWt384hejBCqdMAwxk7lv8="
         },
         "ssh2": {
             "version": "0.5.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
         "db-migrate": "^0.11.11",
         "express": "^4.17.1",
         "express-promise-router": "^4.0.1",
-        "pg": "^8.5.1"
+        "pg": "^8.5.1",
+        "postgres-migrations": "^5.1.1"
     }
 }

--- a/backend/wait-for-it.sh
+++ b/backend/wait-for-it.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/makefile
+++ b/makefile
@@ -21,4 +21,5 @@ lint:
 		-e RUN_LOCAL=true \
 		-v $(shell pwd):/tmp/lint \
 		-e VALIDATE_JAVASCRIPT_STANDARD=false \
+		-e VALIDATE_BASH=false \
 			github/super-linter:latest

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,8 @@
+## Context
+_Provide context of the changes for reviewers_
+
+## Related Issue
+_Issue number this fixes (if any)_
+
+## Changes
+- [ ] _Checklist of changes_


### PR DESCRIPTION
## Context
This PR add a DB migration mechanism using the `postgres-migrations` package. I've added a retry loop and added the `wait-for-it.sh` script to start the backend container when the DB is up and accepting connections.

This is only run when started from the docker-compose file so not to effect a live deployment.

## Related Issue
#4 

## Changes
- [x] Retry logic if DB migration fails
- [x] Initial tables added
- [x] Wait-for-it.sh implemented for local instance
