### PR TITLE
extend status endpoint to show more db info stats

### DIFF
--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
         "./wait-for-it.sh",
         "db:5432",
         "--",
-        "node",
+        "nodemon",
         "app.js"
       ]      
   db:

--- a/backend/makefile
+++ b/backend/makefile
@@ -1,4 +1,4 @@
-run-dev:
+run-backend:
 	docker-compose -f docker-compose.yaml -f docker-compose-debug.yaml up --build -d backend db
 run-pgadmin:
 	docker-compose -f docker-compose.yaml -f docker-compose-debug.yaml up --build -d pgadmin

--- a/backend/routes/status.js
+++ b/backend/routes/status.js
@@ -20,11 +20,11 @@ async function getDbMigrationVersion() {
 }
 
 async function getDbTableInfo() {
-    _categoriesCount = await getNumberOfCategories()
-    _migrationsInfo = await getDbMigrationVersion()
+    const _categoriesCount = await getNumberOfCategories()
+    const _migrationsInfo = await getDbMigrationVersion()
 
 
-    _dbMigrationsInfo = {
+    const _dbMigrationsInfo = {
         DbVersion: _migrationsInfo.rows[0]['id'],
         ScriptName: _migrationsInfo.rows[0]['name'],
         ScriptHash: _migrationsInfo.rows[0]['hash'],

--- a/backend/routes/status.js
+++ b/backend/routes/status.js
@@ -6,16 +6,52 @@ const router = new Router()
 // export our router to be mounted by the parent application
 module.exports = router
 
+
+async function getDbTime() {
+    return await db.query('SELECT NOW();')
+}
+
+async function getNumberOfCategories() {
+    return await db.query('SELECT COUNT(*) FROM categories;')
+}
+
+async function getDbMigrationVersion() {
+    return await db.query('SELECT * FROM migrations ORDER BY id DESC FETCH FIRST 1 ROWS ONLY;')
+}
+
+async function getDbTableInfo() {
+    _categoriesCount = await getNumberOfCategories()
+    _migrationsInfo = await getDbMigrationVersion()
+
+
+    _dbMigrationsInfo = {
+        DbVersion: _migrationsInfo.rows[0]['id'],
+        ScriptName: _migrationsInfo.rows[0]['name'],
+        ScriptHash: _migrationsInfo.rows[0]['hash'],
+        ExecutedAt: _migrationsInfo.rows[0]['executed_at']
+    }
+
+    return {
+        NumberOfCategories: _categoriesCount.rows[0]['count'],
+        DbMigrationsInfo: _dbMigrationsInfo
+    }
+}
+
 router.get('/status', async (req, res) => {
     try {
-        const { rows } = await db.query('SELECT NOW()')
+        const _dbTime = await getDbTime()
+        const _dbTableInfo = await getDbTableInfo()
+
+
         res.send(JSON.stringify({
             DbConnectionStatus: 'OK',
-            DbTimestamp: rows[0]['now']
+            DbTimestamp: _dbTime.rows[0]['now'],
+            DbInfo: [_dbTableInfo]
         }))
     } catch (err) {
         console.error('Failed to connect to database')
         res.send(JSON.stringify({
+            DbConnectionStatus: 'DOWN',
             Error: err
         }))
     }

--- a/makefile
+++ b/makefile
@@ -10,7 +10,7 @@ start-frontend:
 
 start-backend:
 	cd backend && \
-	$(MAKE) run-dev
+	$(MAKE) run-backend
 
 start-pgadmin:
 	cd backend && \


### PR DESCRIPTION
## Context
This PR will introduce some detailed DB stats to the /status endpoint for the backend

## Related Issue
_n/a_

## Changes
- [x] Add DB detailed metrics to backend
